### PR TITLE
Consistent uuids

### DIFF
--- a/client/src/components/Admin/CreateDrink.js
+++ b/client/src/components/Admin/CreateDrink.js
@@ -94,8 +94,8 @@ const CreateDrink = ({setCurrentPage, drinkID, adminKey}) => {
 
         drink.tags = tags;
         drink.ingredients = ingredients;
-        if (typeof drink.abv === "string"){
-            drink.abv = parseFloat((drink.abv||"").replace(",", "."));
+        if (typeof drink.override_volume === "string"){
+            drink.override_volume = parseFloat((drink.override_volume||"").replace(",", "."));
         }
         
         return drink;

--- a/client/src/components/Admin/CreateDrink.js
+++ b/client/src/components/Admin/CreateDrink.js
@@ -122,32 +122,40 @@ const CreateDrink = ({setCurrentPage, drinkID, adminKey}) => {
         }
     }
     async function deleteDrink(sameImage, drinkID) {
-        axios.delete('api/drink/'+drinkID+(sameImage ? '?saveImg=true':''), {headers:{Authorization: `Bearer ${adminKey}`}})
-            .then((res) => {
-                if (res.data) {
-                    console.log(res.data[0]);
-                }
-            }).catch((err) => console.log(err));
+        return new Promise((resolve, reject) => {
+            axios.delete('api/drink/'+drinkID+(sameImage ? '?saveImg=true':''), {headers:{Authorization: `Bearer ${adminKey}`}})
+                .then((res) => {
+                    if (res.data) {
+                        console.log(res.data[0]);
+                        resolve()
+                    }
+                }).catch((err) =>{
+                    console.log(err)
+                    reject(err);
+                });
+        });
     }
 
     const updateDrink = async () => {
         let sameImage = !selectedImage;
-        await deleteDrink(sameImage && imagePreviewURL !== noImageURL, drinkID);
-        await createDrink(sameImage);
+        deleteDrink(sameImage && imagePreviewURL !== noImageURL, drinkID)
+            .then(async ()=>{await createDrink(sameImage)})
+            .catch(console.error('Failed to delete drink.'));
     }
 
     const createDrink = async (sameImage) => {
-        let uuid = imageUUID;
+        let tempImageUUID = imageUUID;
         if (!imageUUID && !sameImage && imagePreviewURL !== noImageURL){
-            uuid = await uploadImage();
-            setImageUUID(uuid);
+            tempImageUUID = await uploadImage();
+            setImageUUID(tempImageUUID);
         }
         let drink = {};
-        if (uuid) {
-            drink = parseDrink({...inputs, image:uuid});
+        if (tempImageUUID) {
+            drink = parseDrink({...inputs, image:tempImageUUID});
         } else {
             drink = parseDrink(inputs);
         }
+        if(drinkID) drink.uuid = drinkID;
         let error = validateDrink(drink);
         if (error) {
             setErrorMsg(error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mixd",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/routes/api.js
+++ b/routes/api.js
@@ -258,7 +258,11 @@ router.post('/add_drink', verifyRequest, (req, res, next) => {
         delete req.body._id
         delete req.body.__v
 
-        let new_drink = {...req.body, uuid: uuid()}
+        let new_drink = req.body
+        if(new_drink.uuid === undefined){
+            new_drink = {...req.body, uuid: uuid()}
+        }
+
         new_drink.volume = calculateDrinkVolume(new_drink)
         Drinks.create(new_drink)
             .then((data) => {


### PR DESCRIPTION
Drink UUIDs now do not change when the drink is updated. This will fix hyperlinks embed into drink pages. Image UUIDs have been left separate from drink UUIDs as their own ID space. Timing of deleting the old version of the drink then adding the new one has been adjusted to ideally fix the occurrence of double drink entries. This fixes issue #70.