### PR TITLE
Cycle dot color using cookies

### DIFF
--- a/client/src/components/DotColor.js
+++ b/client/src/components/DotColor.js
@@ -1,13 +1,20 @@
 import React, { useState, useEffect } from "react";
+import { useCookies } from "react-cookie";
 
 const DotColor = ({toggleAdminMode}) => {
 
     const [color, setColor] = useState('#FFFFFF');
+    const [cookies, setCookie] = useCookies(['colorIndex']);
 
     useEffect(() => {
-        let i = Math.floor(Math.random() * 5);
-        let colors = ["#7856a1", "#5096ab", "#d6a038", "#6f8548", "#d66d2a"];
-        setColor(colors[i]);
+        let dotColors = ["#7856a1", "#5096ab", "#d6a038", "#6f8548", "#d66d2a"];
+        let colorIndex = cookies.colorIndex;
+        setColor(dotColors[colorIndex])
+        if(colorIndex < 4) {
+            setCookie('colorIndex', ++colorIndex)
+        } else {
+            setCookie('colorIndex', 0);
+        }
     }, []);
 
     return (

--- a/client/src/components/DotColor.js
+++ b/client/src/components/DotColor.js
@@ -8,7 +8,7 @@ const DotColor = ({toggleAdminMode}) => {
 
     useEffect(() => {
         let dotColors = ["#7856a1", "#5096ab", "#d6a038", "#6f8548", "#d66d2a"];
-        let colorIndex = cookies.colorIndex;
+        let colorIndex = cookies.colorIndex || 0;
         setColor(dotColors[colorIndex])
         if(colorIndex < 4) {
             setCookie('colorIndex', ++colorIndex)


### PR DESCRIPTION
Closes #82

Creates new colorIndex cookie to store the dot color across page reloads. 

Instead of randomly picking a color, the index for the dotColor array is incremented each page refresh. This prevents users from getting "orange, green, orange, green, etc.)