### PR TITLE
Update menu page navigation

### DIFF
--- a/client/src/components/Admin/DoneEntry.js
+++ b/client/src/components/Admin/DoneEntry.js
@@ -1,0 +1,21 @@
+import React from "react"
+import {FaCheck} from "react-icons/fa";
+import "../../format/DrinkList.css";
+
+const DoneEntry = ({}) => {
+
+    return (
+        <div className="list-entry" style={{cursor: "pointer"}}>
+            <div className="glass-container">
+                <FaCheck style={{margin: '30px', fontSize:'30px'}}/>
+            </div>
+            <div className="list-column">
+                <div>
+                    <p className="list-title">Done</p>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default DoneEntry;

--- a/client/src/components/DrinkList/DrinkEntry.js
+++ b/client/src/components/DrinkList/DrinkEntry.js
@@ -77,7 +77,7 @@ const DrinkEntry = ({drink, getDrinkList, adminKey, filteredTags, setShowLoader,
        if(menu_id){
            axios.post('/api/add_menu_drink', {menu_id:menu_id, drink: drink.uuid}).then((res)=>{
                if(res.status && res.status === 200){
-                   navigate('/menu/'+menu_id+'#edit', {replace: true});
+                   navigate(-1, {replace: true});
                }
            });
        }

--- a/client/src/pages/Layout.js
+++ b/client/src/pages/Layout.js
@@ -24,7 +24,7 @@ const Layout = ({showLoader, setShowLoader}) => {
 
     function isMenuPage() {
         let split_path = location.pathname.split('/');
-        return split_path.length > 1 && split_path[1]==='menu';
+        return split_path.length > 1 && split_path[1]==='menu' && !location.hash;
     }
 
     function backArrowClicked() {

--- a/client/src/pages/Layout.js
+++ b/client/src/pages/Layout.js
@@ -22,6 +22,11 @@ const Layout = ({showLoader, setShowLoader}) => {
         return !reserved_routes.includes(location.pathname.substring(1));
     }
 
+    function isMenuPage() {
+        let split_path = location.pathname.split('/');
+        return split_path.length > 1 && split_path[1]==='menu';
+    }
+
     function backArrowClicked() {
         navigate(-1);
         navigate('/');
@@ -56,7 +61,7 @@ const Layout = ({showLoader, setShowLoader}) => {
             {displayNavBar() && <nav>
                 <div className="nav-container">
                     <div style={{display:"flex"}}>
-                        <div className="back" style={{cursor: "pointer"}} onClick={()=> backArrowClicked()}><FaChevronLeft/></div>
+                        {!isMenuPage() && <div className="back" style={{cursor: "pointer"}} onClick={()=> backArrowClicked()}><FaChevronLeft/></div>}
                         <Link to='/' className="nav-logo">mixd.</Link>
                     </div>
                     <div>

--- a/client/src/pages/MenuPage.js
+++ b/client/src/pages/MenuPage.js
@@ -4,6 +4,7 @@ import axios from "axios";
 import DrinkArray from "../components/DrinkList/DrinkArray";
 import AddDrinkEntry from "../components/Admin/AddDrinkEntry";
 import "../format/MenuPage.css";
+import DoneEntry from "../components/Admin/DoneEntry";
 const MenuPage = ({setShowLoader}) => {
 
     const { menu_id } = useParams();
@@ -33,6 +34,8 @@ const MenuPage = ({setShowLoader}) => {
             {hash==='#edit' && <div>
                 <hr className="list-separator" />
                 <Link to={'/#edit_menu-'+menu.menu_id}><AddDrinkEntry /></Link>
+                <hr className="list-separator" />
+                <div onClick={()=>{navigate('/menu/'+menu.menu_id, {replace: true})}}><DoneEntry /></div>
             </div>}
         </>
     )


### PR DESCRIPTION
Removes back arrow on menu page. Users are likely to be landing on this page from a link or QR code. Going back is confusing. Also improves navigation on menu edit page. Editing can be stopped and the weird stacking of navigation history on drink add has been fixed.