### PR TITLE
10 sort by abv

### DIFF
--- a/client/src/components/Statistics/AlcoholContentCard.js
+++ b/client/src/components/Statistics/AlcoholContentCard.js
@@ -1,0 +1,40 @@
+import React, {useEffect, useState} from "react"
+import axios from "axios";
+import AlcoholContentCardDrinkEntry from "./AlcoholContentCardDrinkEntry";
+import "../../format/StatisticsTab.css";
+import "../../format/AlcoholContentStatistics.css";
+import {getColor} from "../../components/DrinkTags";
+
+const AlcoholContentCard = ({ title, onDrinkClick, stat, listLength, sort }) => {
+
+    const [statList, setStatList] = useState([]);
+
+    useEffect(() => {
+        fetchAlcoholContentStats();
+    }, []);
+
+    const fetchAlcoholContentStats = () => {
+        axios.get(`/api/statistics?stat=${stat}&n=${listLength}&sort=${sort}`)
+            .then((res) => {
+                if (res.data) {
+                    setStatList(res.data);
+                }
+            }).catch((err) => console.log(err));
+    }
+
+    return (
+        <div className="alcohol-card">
+            <h3 className="statistics-category-title">{title}</h3>
+            {statList.length === 0 && <div className="statistics-empty">No drinks available</div>}
+            {statList.map((drink, index) => {
+                const value = drink[stat];
+                const formattedValue = typeof value === 'number' ? value.toFixed(1) : '';
+                const unitMap = {abv: '%', emu: ' EMU'};
+                const unit = unitMap[stat] || '';
+                return <AlcoholContentCardDrinkEntry drink={drink} formattedValue={formattedValue} unit={unit} onDrinkClick={onDrinkClick}/>
+            })}
+        </div>
+    )
+}
+
+export default AlcoholContentCard;

--- a/client/src/components/Statistics/AlcoholContentCardDrinkEntry.js
+++ b/client/src/components/Statistics/AlcoholContentCardDrinkEntry.js
@@ -1,0 +1,30 @@
+import { getColor } from "../DrinkTags";
+import "../../format/AlcoholContentStatistics.css"
+
+const AlcoholContentCardDrinkEntry = ({drink, formattedValue, unit, onDrinkClick}) => {
+    
+    return (
+        <>
+            <hr className="alcohol-card-hr"/>
+            <div className="alcohol-card-drink-entry" onClick={() => onDrinkClick(drink)}>
+                <div className="alcohol-card-drink-entry-left">
+                    {drink.glass ?
+                        <img className="alcohol-card-drink-entry-glass" src={`/api/image?file=glassware/${drink.glass.toLowerCase()}.svg&backup=glassware/unknown.svg`} alt={`${drink.glass} glass`} /> :
+                        <img className="alcohol-card-drink-entry-glass" src="/api/image?file=glassware/unknown.svg" alt="No glass listed" />
+                    }
+                    <div className="alcohol-card-drink-entry-info">
+                        <div className="alcohol-card-drink-entry-title">{drink.name}</div>
+                        <div style={{display: "flex", marginTop: "5px"}}>
+                            {drink.tags && drink.tags.map(tag => (
+                                <div className="alcohol-card-drink-entry-tag" style={{backgroundColor: getColor(tag)}}></div>
+                            ))}
+                        </div>
+                    </div>
+                </div>
+                <span className="alcohol-card-abv-value">{formattedValue}{unit}</span>
+            </div>
+        </>
+    )
+}
+
+export default AlcoholContentCardDrinkEntry;

--- a/client/src/format/AlcoholContentStatistics.css
+++ b/client/src/format/AlcoholContentStatistics.css
@@ -1,0 +1,63 @@
+.alcohol-card {
+    background-color: rgba(255, 255, 255, 0.15);
+    width: 300px;
+    padding: 10px;
+    margin: 10px;
+    border-radius: 10px;
+    overflow: visible;
+    box-sizing: border-box;
+    color: white;
+}
+
+.alcohol-card-drink-entry {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    cursor: pointer;
+    text-align: left;
+}
+
+.alcohol-card-drink-entry-left {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.alcohol-card-drink-entry-glass {
+    height: 50px;
+    margin: -5px 0 -5px 0;
+}
+
+.alcohol-card-drink-entry-info {
+    align-content: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.alcohol-card-drink-entry-title {
+    font-weight: 300;
+    font-size: 18px;
+    margin: -2px 0 0 0;
+}
+
+.alcohol-card-drink-entry-tag {
+    height: 8px;
+    width: 8px;
+    border-radius: 10px;
+    margin-right: 5px;
+}
+
+.alcohol-card-abv-value {
+    margin-left: 12px;
+    min-width: 50px;
+    text-align: right;
+    color: white;
+}
+
+@media screen and (max-width: 600px) {
+    .alcohol-card {
+        width: 100%;
+    }
+}

--- a/client/src/format/AlcoholContentStatistics.css
+++ b/client/src/format/AlcoholContentStatistics.css
@@ -1,6 +1,6 @@
 .alcohol-card {
     background-color: rgba(255, 255, 255, 0.15);
-    width: 300px;
+    width: 400px;
     padding: 10px;
     margin: 10px;
     border-radius: 10px;
@@ -58,6 +58,6 @@
 
 @media screen and (max-width: 600px) {
     .alcohol-card {
-        width: 100%;
+        width: 85%;
     }
 }

--- a/client/src/format/AlcoholContentStatistics.css
+++ b/client/src/format/AlcoholContentStatistics.css
@@ -49,6 +49,13 @@
     margin-right: 5px;
 }
 
+.alcohol-card-hr {
+    border-top: 2px solid darkgray;
+    border-bottom: 0px;
+    border-left: 0px;
+    border-right: 0px;
+}
+
 .alcohol-card-abv-value {
     margin-left: 12px;
     min-width: 50px;

--- a/client/src/format/StatisticsTab.css
+++ b/client/src/format/StatisticsTab.css
@@ -1,16 +1,16 @@
-.ingredient-category-container {
+.statistics-category-container {
     width: 300px;
     margin-bottom: 25px;
 }
 
-.ingredient-category-title {
+.statistics-category-title {
     font-weight: 400;
     font-size: 25px;
     text-align: center;
     margin: 0px 0px 5px 0px;
 }
 
-.ingredient-sort-instructions {
+.statistics-sort-instructions {
     font-weight: 300;
     font-size: 18px;
     color: darkgray;    
@@ -18,22 +18,22 @@
     margin: 0 0 15px 0;
 }
 
-.ingredient-usage-container {
+.statistics-usage-container {
     display: flex;
     flex-flow: row wrap;
     justify-content: center;
 }
 
 @media screen and (max-width: 600px) {
-    .ingredient-category-container {
+    .statistics-category-container {
         width: 100%;
     }
 
-    .ingredient-category-title {
+    .statistics-category-title {
         font-size: 28px;
     }
 
-    .ingredient-sort-instructions {
+    .statistics-sort-instructions {
         margin-bottom: 10px;
     }
 }

--- a/client/src/pages/account/StatisticsTab.js
+++ b/client/src/pages/account/StatisticsTab.js
@@ -51,7 +51,7 @@ const StatisticsTab = ({setSearchIngredient}) => {
             }).catch((err) => console.log(err));
     }
 
-    const renderDrinkContainer = (title, drinks) => (
+    const renderABVContainer = (title, drinks) => (
         <div className="alcohol-card">
             <h3 className="statistics-category-title">{title}</h3>
             {drinks.length === 0 && <div className="statistics-empty">No drinks available</div>}
@@ -108,8 +108,8 @@ const StatisticsTab = ({setSearchIngredient}) => {
             <h2 className="tab-subtitle">Alcohol Content</h2>
             <p className="statistics-sort-instructions">Top {ABV_STATS_LIST_LENGTH} highest and lowest ABV drinks!</p>
             <div className="statistics-usage-container">
-                {renderDrinkContainer('Highest ABV', highestAbvDrinks)}
-                {renderDrinkContainer('Lowest ABV', lowestAbvDrinks)}
+                {renderABVContainer('Highest ABV', highestAbvDrinks)}
+                {renderABVContainer('Lowest ABV', lowestAbvDrinks)}
             </div>
         </>
     )

--- a/client/src/pages/account/StatisticsTab.js
+++ b/client/src/pages/account/StatisticsTab.js
@@ -2,17 +2,24 @@ import React, {useEffect, useState} from "react"
 import axios from "axios";
 import IngredientListEntry from "../../components/Ingredients/IngredientListEntry";
 import "../../format/StatisticsTab.css";
+import "../../format/AlcoholContentStatistics.css";
 import "../../format/Tabs.css";
 import {useNavigate} from "react-router-dom";
 import IngredientCategories from "../../definitions/IngredientCategories";
+import {getColor} from "../../components/DrinkTags";
+
+const ABV_STATS_LIST_LENGTH = process.env.ABV_STATS_LIST_LENGTH || 10;
 
 const StatisticsTab = ({setSearchIngredient}) => {
     const [ingredients, setIngredients] = useState([]);
+    const [highestAbvDrinks, setHighestAbvDrinks] = useState([]);
+    const [lowestAbvDrinks, setLowestAbvDrinks] = useState([]);
 
     const navigate = useNavigate();
 
     useEffect(() => {
         fetchIngredients();
+        fetchAbvStats();
     }, []);
 
     const fetchIngredients = () => {
@@ -27,6 +34,55 @@ const StatisticsTab = ({setSearchIngredient}) => {
     const onIngredientClick = (ingredient) => {
         setSearchIngredient(ingredient.uuid);
         navigate('/');
+    };
+
+    const fetchAbvStats = () => {
+        axios.get(`/api/highest_abv?n=${ABV_STATS_LIST_LENGTH}`)
+            .then((res) => {
+                if (res.data) {
+                    setHighestAbvDrinks(res.data);
+                }
+            }).catch((err) => console.log(err));
+        axios.get(`/api/lowest_abv?n=${ABV_STATS_LIST_LENGTH}`)
+            .then((res) => {
+                if (res.data) {
+                    setLowestAbvDrinks(res.data);
+                }
+            }).catch((err) => console.log(err));
+    }
+
+    const renderDrinkContainer = (title, drinks) => (
+        <div className="alcohol-card">
+            <h3 className="statistics-category-title">{title}</h3>
+            {drinks.length === 0 && <div className="statistics-empty">No drinks available</div>}
+            {drinks.map((drink, index) => (
+                <React.Fragment key={drink.uuid}>
+                    {index > 0 && <hr />}
+                    <div className="alcohol-card-drink-entry" onClick={() => onDrinkClick(drink)}>
+                        <div className="alcohol-card-drink-entry-left">
+                            {drink.glass ?
+                                <img className="alcohol-card-drink-entry-glass" src={`/api/image?file=glassware/${drink.glass.toLowerCase()}.svg&backup=glassware/unknown.svg`} alt={`${drink.glass} glass`} /> :
+                                <img className="alcohol-card-drink-entry-glass" src="/api/image?file=glassware/unknown.svg" alt="No glass listed" />
+                            }
+                            <div className="alcohol-card-drink-entry-info">
+                                <div className="alcohol-card-drink-entry-title">{drink.name}</div>
+                                <div style={{display: "flex", marginTop: "5px"}}>
+                                    {drink.tags && drink.tags.map((tag, index) => (
+                                        <div key={index} className="alcohol-card-drink-entry-tag" style={{backgroundColor: getColor(tag)}}></div>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+                        <span className="alcohol-card-abv-value">{(drink.abv).toFixed(1)}%</span>
+                    </div>
+                </React.Fragment>
+            ))}
+        </div>
+    );
+
+    const onDrinkClick = (drink) => {
+        const identifier = drink.url_name || drink.uuid;
+        navigate(`/${identifier}`);
     };
 
     return (
@@ -47,6 +103,13 @@ const StatisticsTab = ({setSearchIngredient}) => {
                         })}
                     </div>
                 })}
+            </div>
+            <hr></hr>
+            <h2 className="tab-subtitle">Alcohol Content</h2>
+            <p className="statistics-sort-instructions">Top {ABV_STATS_LIST_LENGTH} highest and lowest ABV drinks!</p>
+            <div className="statistics-usage-container">
+                {renderDrinkContainer('Highest ABV', highestAbvDrinks)}
+                {renderDrinkContainer('Lowest ABV', lowestAbvDrinks)}
             </div>
         </>
     )

--- a/client/src/pages/account/StatisticsTab.js
+++ b/client/src/pages/account/StatisticsTab.js
@@ -74,7 +74,7 @@ const StatisticsTab = ({setSearchIngredient}) => {
                 const formattedValue = typeof value === 'number' ? value.toFixed(1) : '';
                 return (
                     <React.Fragment key={drink.uuid}>
-                        {index > 0 && <hr />}
+                        {index > 0 && <hr className="alcohol-card-hr"/>}
                         <div className="alcohol-card-drink-entry" onClick={() => onDrinkClick(drink)}>
                             <div className="alcohol-card-drink-entry-left">
                                 {drink.glass ?

--- a/client/src/pages/account/StatisticsTab.js
+++ b/client/src/pages/account/StatisticsTab.js
@@ -106,6 +106,15 @@ const StatisticsTab = ({setSearchIngredient}) => {
     return (
         <>
             <h1 className="tab-title">Statistics</h1>
+            <h2 className="tab-subtitle">Alcohol Content</h2>
+            <p className="statistics-sort-instructions">Top {ALCOHOL_STATS_LIST_LENGTH} most and least alcoholic drinks!</p>
+            <div className="statistics-usage-container">
+                {renderAlcoholStatContainer('Highest ABV', highestAbvDrinks, 'abv', '%')}
+                {renderAlcoholStatContainer('Lowest ABV', lowestAbvDrinks, 'abv', '%')}
+                {renderAlcoholStatContainer('Highest EMU', highestEmuDrinks, 'emu', ' EMU')}
+                {renderAlcoholStatContainer('Lowest EMU', lowestEmuDrinks, 'emu', ' EMU')}
+            </div>
+            <hr></hr>
             <h2 className="tab-subtitle">Ingredient Usage</h2>
             <p className="statistics-sort-instructions">Click on an ingredient to show all drinks using that ingredient!</p>
             <div className="statistics-usage-container">
@@ -121,16 +130,7 @@ const StatisticsTab = ({setSearchIngredient}) => {
                         })}
                     </div>
                 })}
-            </div>
-            <hr></hr>
-            <h2 className="tab-subtitle">Alcohol Content</h2>
-            <p className="statistics-sort-instructions">Top {ALCOHOL_STATS_LIST_LENGTH} most and least alcoholic drinks!</p>
-            <div className="statistics-usage-container">
-                {renderAlcoholStatContainer('Highest ABV', highestAbvDrinks, 'abv', '%')}
-                {renderAlcoholStatContainer('Lowest ABV', lowestAbvDrinks, 'abv', '%')}
-                {renderAlcoholStatContainer('Highest EMU', highestEmuDrinks, 'emu', ' EMU')}
-                {renderAlcoholStatContainer('Lowest EMU', lowestEmuDrinks, 'emu', ' EMU')}
-            </div>
+            </div>            
         </>
     )
 }

--- a/client/src/pages/account/StatisticsTab.js
+++ b/client/src/pages/account/StatisticsTab.js
@@ -33,13 +33,13 @@ const StatisticsTab = ({setSearchIngredient}) => {
         <>
             <h1 className="tab-title">Statistics</h1>
             <h2 className="tab-subtitle">Ingredient Usage</h2>
-            <p className="ingredient-sort-instructions">Click on an ingredient to show all drinks using that ingredient!</p>
-            <div className="ingredient-usage-container">
+            <p className="statistics-sort-instructions">Click on an ingredient to show all drinks using that ingredient!</p>
+            <div className="statistics-usage-container">
                 {IngredientCategories.map(category => {
                     let category_ingr = ingredients.filter(ingr => ingr.category === category.name);
                     if(category_ingr.length === 0) return <></>
-                    return <div className="ingredient-category-container">
-                        <h3 className="ingredient-category-title">{category.header}</h3>
+                    return <div className="statistics-category-container">
+                        <h3 className="statistics-category-title">{category.header}</h3>
                         {category_ingr.map((ingredient) =>{
                             return <div>
                                 {ingredient.count > 0 && <IngredientListEntry ingredient={ingredient} onIngredientClick={onIngredientClick}/>}

--- a/client/src/pages/account/StatisticsTab.js
+++ b/client/src/pages/account/StatisticsTab.js
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from "react"
 import axios from "axios";
 import IngredientListEntry from "../../components/Ingredients/IngredientListEntry";
+import AlcoholContentCard from "../../components/Statistics/AlcoholContentCard";
 import "../../format/StatisticsTab.css";
 import "../../format/AlcoholContentStatistics.css";
 import "../../format/Tabs.css";
@@ -21,7 +22,6 @@ const StatisticsTab = ({setSearchIngredient}) => {
 
     useEffect(() => {
         fetchIngredients();
-        fetchAlcoholContentStats();
     }, []);
 
     const fetchIngredients = () => {
@@ -37,33 +37,6 @@ const StatisticsTab = ({setSearchIngredient}) => {
         setSearchIngredient(ingredient.uuid);
         navigate('/');
     };
-
-    const fetchAlcoholContentStats = () => {
-        axios.get(`/api/statistics?stat=abv&n=${ALCOHOL_STATS_LIST_LENGTH}&sort=desc`)
-            .then((res) => {
-                if (res.data) {
-                    setHighestAbvDrinks(res.data);
-                }
-            }).catch((err) => console.log(err));
-        axios.get(`/api/statistics?stat=abv&n=${ALCOHOL_STATS_LIST_LENGTH}&sort=asc`)
-            .then((res) => {
-                if (res.data) {
-                    setLowestAbvDrinks(res.data);
-                }
-            }).catch((err) => console.log(err));
-        axios.get(`/api/statistics?stat=emu&n=${ALCOHOL_STATS_LIST_LENGTH}&sort=desc`)
-            .then((res) => {
-                if (res.data) {
-                    setHighestEmuDrinks(res.data);
-                }
-            }).catch((err) => console.log(err));
-        axios.get(`/api/statistics?stat=emu&n=${ALCOHOL_STATS_LIST_LENGTH}&sort=asc`)
-            .then((res) => {
-                if (res.data) {
-                    setLowestEmuDrinks(res.data);
-                }
-            }).catch((err) => console.log(err));
-    }
 
     const renderAlcoholStatContainer = (title, drinks, valueKey, unit) => (
         <div className="alcohol-card">
@@ -109,10 +82,10 @@ const StatisticsTab = ({setSearchIngredient}) => {
             <h2 className="tab-subtitle">Alcohol Content</h2>
             <p className="statistics-sort-instructions">Top {ALCOHOL_STATS_LIST_LENGTH} most and least alcoholic drinks!</p>
             <div className="statistics-usage-container">
-                {renderAlcoholStatContainer('Highest ABV', highestAbvDrinks, 'abv', '%')}
-                {renderAlcoholStatContainer('Lowest ABV', lowestAbvDrinks, 'abv', '%')}
-                {renderAlcoholStatContainer('Highest EMU', highestEmuDrinks, 'emu', ' EMU')}
-                {renderAlcoholStatContainer('Lowest EMU', lowestEmuDrinks, 'emu', ' EMU')}
+                <AlcoholContentCard title="Highest ABV" onDrinkClick={onDrinkClick} stat="abv" listLength={ALCOHOL_STATS_LIST_LENGTH} sort="desc"/>
+                <AlcoholContentCard title="Lowest ABV" onDrinkClick={onDrinkClick} stat="abv" listLength={ALCOHOL_STATS_LIST_LENGTH} sort="asc"/>
+                <AlcoholContentCard title="Highest EMU" onDrinkClick={onDrinkClick} stat="emu" listLength={ALCOHOL_STATS_LIST_LENGTH} sort="desc"/>
+                <AlcoholContentCard title="Lowest EMU" onDrinkClick={onDrinkClick} stat="emu" listLength={ALCOHOL_STATS_LIST_LENGTH} sort="asc"/>
             </div>
             <hr></hr>
             <h2 className="tab-subtitle">Ingredient Usage</h2>

--- a/client/src/pages/account/StatisticsTab.js
+++ b/client/src/pages/account/StatisticsTab.js
@@ -8,18 +8,20 @@ import {useNavigate} from "react-router-dom";
 import IngredientCategories from "../../definitions/IngredientCategories";
 import {getColor} from "../../components/DrinkTags";
 
-const ABV_STATS_LIST_LENGTH = process.env.ABV_STATS_LIST_LENGTH || 10;
+const ALCOHOL_STATS_LIST_LENGTH = process.env.ALCOHOL_STATS_LIST_LENGTH || 10;
 
 const StatisticsTab = ({setSearchIngredient}) => {
     const [ingredients, setIngredients] = useState([]);
     const [highestAbvDrinks, setHighestAbvDrinks] = useState([]);
     const [lowestAbvDrinks, setLowestAbvDrinks] = useState([]);
+    const [highestEmuDrinks, setHighestEmuDrinks] = useState([]);
+    const [lowestEmuDrinks, setLowestEmuDrinks] = useState([]);
 
     const navigate = useNavigate();
 
     useEffect(() => {
         fetchIngredients();
-        fetchAbvStats();
+        fetchAlcoholContentStats();
     }, []);
 
     const fetchIngredients = () => {
@@ -36,47 +38,63 @@ const StatisticsTab = ({setSearchIngredient}) => {
         navigate('/');
     };
 
-    const fetchAbvStats = () => {
-        axios.get(`/api/highest_abv?n=${ABV_STATS_LIST_LENGTH}`)
+    const fetchAlcoholContentStats = () => {
+        axios.get(`/api/highest_abv?n=${ALCOHOL_STATS_LIST_LENGTH}`)
             .then((res) => {
                 if (res.data) {
                     setHighestAbvDrinks(res.data);
                 }
             }).catch((err) => console.log(err));
-        axios.get(`/api/lowest_abv?n=${ABV_STATS_LIST_LENGTH}`)
+        axios.get(`/api/lowest_abv?n=${ALCOHOL_STATS_LIST_LENGTH}`)
             .then((res) => {
                 if (res.data) {
                     setLowestAbvDrinks(res.data);
                 }
             }).catch((err) => console.log(err));
+        axios.get(`/api/highest_emu?n=${ALCOHOL_STATS_LIST_LENGTH}`)
+            .then((res) => {
+                if (res.data) {
+                    setHighestEmuDrinks(res.data);
+                }
+            }).catch((err) => console.log(err));
+        axios.get(`/api/lowest_emu?n=${ALCOHOL_STATS_LIST_LENGTH}`)
+            .then((res) => {
+                if (res.data) {
+                    setLowestEmuDrinks(res.data);
+                }
+            }).catch((err) => console.log(err));
     }
 
-    const renderABVContainer = (title, drinks) => (
+    const renderAlcoholStatContainer = (title, drinks, valueKey, unit) => (
         <div className="alcohol-card">
             <h3 className="statistics-category-title">{title}</h3>
             {drinks.length === 0 && <div className="statistics-empty">No drinks available</div>}
-            {drinks.map((drink, index) => (
-                <React.Fragment key={drink.uuid}>
-                    {index > 0 && <hr />}
-                    <div className="alcohol-card-drink-entry" onClick={() => onDrinkClick(drink)}>
-                        <div className="alcohol-card-drink-entry-left">
-                            {drink.glass ?
-                                <img className="alcohol-card-drink-entry-glass" src={`/api/image?file=glassware/${drink.glass.toLowerCase()}.svg&backup=glassware/unknown.svg`} alt={`${drink.glass} glass`} /> :
-                                <img className="alcohol-card-drink-entry-glass" src="/api/image?file=glassware/unknown.svg" alt="No glass listed" />
-                            }
-                            <div className="alcohol-card-drink-entry-info">
-                                <div className="alcohol-card-drink-entry-title">{drink.name}</div>
-                                <div style={{display: "flex", marginTop: "5px"}}>
-                                    {drink.tags && drink.tags.map((tag, index) => (
-                                        <div key={index} className="alcohol-card-drink-entry-tag" style={{backgroundColor: getColor(tag)}}></div>
-                                    ))}
+            {drinks.map((drink, index) => {
+                const value = drink[valueKey];
+                const formattedValue = typeof value === 'number' ? value.toFixed(1) : '';
+                return (
+                    <React.Fragment key={drink.uuid}>
+                        {index > 0 && <hr />}
+                        <div className="alcohol-card-drink-entry" onClick={() => onDrinkClick(drink)}>
+                            <div className="alcohol-card-drink-entry-left">
+                                {drink.glass ?
+                                    <img className="alcohol-card-drink-entry-glass" src={`/api/image?file=glassware/${drink.glass.toLowerCase()}.svg&backup=glassware/unknown.svg`} alt={`${drink.glass} glass`} /> :
+                                    <img className="alcohol-card-drink-entry-glass" src="/api/image?file=glassware/unknown.svg" alt="No glass listed" />
+                                }
+                                <div className="alcohol-card-drink-entry-info">
+                                    <div className="alcohol-card-drink-entry-title">{drink.name}</div>
+                                    <div style={{display: "flex", marginTop: "5px"}}>
+                                        {drink.tags && drink.tags.map((tag, index) => (
+                                            <div key={index} className="alcohol-card-drink-entry-tag" style={{backgroundColor: getColor(tag)}}></div>
+                                        ))}
+                                    </div>
                                 </div>
                             </div>
+                            <span className="alcohol-card-abv-value">{formattedValue}{unit}</span>
                         </div>
-                        <span className="alcohol-card-abv-value">{(drink.abv).toFixed(1)}%</span>
-                    </div>
-                </React.Fragment>
-            ))}
+                    </React.Fragment>
+                )
+            })}
         </div>
     );
 
@@ -106,10 +124,12 @@ const StatisticsTab = ({setSearchIngredient}) => {
             </div>
             <hr></hr>
             <h2 className="tab-subtitle">Alcohol Content</h2>
-            <p className="statistics-sort-instructions">Top {ABV_STATS_LIST_LENGTH} highest and lowest ABV drinks!</p>
+            <p className="statistics-sort-instructions">Top {ALCOHOL_STATS_LIST_LENGTH} most and least alcoholic drinks!</p>
             <div className="statistics-usage-container">
-                {renderABVContainer('Highest ABV', highestAbvDrinks)}
-                {renderABVContainer('Lowest ABV', lowestAbvDrinks)}
+                {renderAlcoholStatContainer('Highest ABV', highestAbvDrinks, 'abv', '%')}
+                {renderAlcoholStatContainer('Lowest ABV', lowestAbvDrinks, 'abv', '%')}
+                {renderAlcoholStatContainer('Highest EMU', highestEmuDrinks, 'emu', ' EMU')}
+                {renderAlcoholStatContainer('Lowest EMU', lowestEmuDrinks, 'emu', ' EMU')}
             </div>
         </>
     )

--- a/client/src/pages/account/StatisticsTab.js
+++ b/client/src/pages/account/StatisticsTab.js
@@ -130,7 +130,7 @@ const StatisticsTab = ({setSearchIngredient}) => {
                         })}
                     </div>
                 })}
-            </div>            
+            </div>
         </>
     )
 }

--- a/client/src/pages/account/StatisticsTab.js
+++ b/client/src/pages/account/StatisticsTab.js
@@ -39,25 +39,25 @@ const StatisticsTab = ({setSearchIngredient}) => {
     };
 
     const fetchAlcoholContentStats = () => {
-        axios.get(`/api/highest_abv?n=${ALCOHOL_STATS_LIST_LENGTH}`)
+        axios.get(`/api/statistics?stat=abv&n=${ALCOHOL_STATS_LIST_LENGTH}&sort=desc`)
             .then((res) => {
                 if (res.data) {
                     setHighestAbvDrinks(res.data);
                 }
             }).catch((err) => console.log(err));
-        axios.get(`/api/lowest_abv?n=${ALCOHOL_STATS_LIST_LENGTH}`)
+        axios.get(`/api/statistics?stat=abv&n=${ALCOHOL_STATS_LIST_LENGTH}&sort=asc`)
             .then((res) => {
                 if (res.data) {
                     setLowestAbvDrinks(res.data);
                 }
             }).catch((err) => console.log(err));
-        axios.get(`/api/highest_emu?n=${ALCOHOL_STATS_LIST_LENGTH}`)
+        axios.get(`/api/statistics?stat=emu&n=${ALCOHOL_STATS_LIST_LENGTH}&sort=desc`)
             .then((res) => {
                 if (res.data) {
                     setHighestEmuDrinks(res.data);
                 }
             }).catch((err) => console.log(err));
-        axios.get(`/api/lowest_emu?n=${ALCOHOL_STATS_LIST_LENGTH}`)
+        axios.get(`/api/statistics?stat=emu&n=${ALCOHOL_STATS_LIST_LENGTH}&sort=asc`)
             .then((res) => {
                 if (res.data) {
                     setLowestEmuDrinks(res.data);

--- a/routes/api.js
+++ b/routes/api.js
@@ -339,7 +339,7 @@ router.get('/statistics', (req, res, next) => {
         {$sort: {abv: sortOrder, name: 1}},
         {$limit: limit}
         ]).then((data) => res.json(data)).catch(next);
-    } 
+    }
     
     else if (statistic === 'emu') {
         Drinks.aggregate([

--- a/routes/api.js
+++ b/routes/api.js
@@ -311,6 +311,7 @@ router.get('/statistics', (req, res, next) => {
 
     if (statistic === 'abv') {
         Drinks.aggregate([
+        {$match: {etoh: {$gt: 0}}},
         {
             $project: {
                 uuid: 1,
@@ -343,6 +344,7 @@ router.get('/statistics', (req, res, next) => {
     
     else if (statistic === 'emu') {
         Drinks.aggregate([
+        {$match: {etoh: {$gt: 0}}},
         {
             $project: {
                 uuid: 1,

--- a/routes/api.js
+++ b/routes/api.js
@@ -371,6 +371,54 @@ router.get('/lowest_abv', (req, res, next) => {
     ]).then((data) => res.json(data)).catch(next);
 });
 
+router.get('/highest_emu', (req, res, next) => {
+    const limit = parsePositiveLimit(req.query.n) || 10;
+    Drinks.aggregate([
+        {
+            $project: {
+                uuid: 1,
+                name: 1,
+                url_name: 1,
+                tags: 1,
+                glass: 1,
+                emu: {
+                    $cond: [
+                        {$gt: ['$etoh', 0]},
+                        {$divide: [{$round: [{$divide: ['$etoh', 5.04]}, 1]}, 10]},
+                        0
+                    ]
+                }
+            }
+        },
+        {$sort: {emu: -1, name: 1}},
+        {$limit: limit}
+    ]).then((data) => res.json(data)).catch(next);
+});
+
+router.get('/lowest_emu', (req, res, next) => {
+    const limit = parsePositiveLimit(req.query.n) || 10;
+    Drinks.aggregate([
+        {
+            $project: {
+                uuid: 1,
+                name: 1,
+                url_name: 1,
+                tags: 1,
+                glass: 1,
+                emu: {
+                    $cond: [
+                        {$gt: ['$etoh', 0]},
+                        {$divide: [{$round: [{$divide: ['$etoh', 5.04]}, 1]}, 10]},
+                        0
+                    ]
+                }
+            }
+        },
+        {$sort: {emu: 1, name: 1}},
+        {$limit: limit}
+    ]).then((data) => res.json(data)).catch(next);
+});
+
 router.get('/search', async (req, res, next) => {
     let pipeline = [];
     let myBarAggregate;

--- a/routes/api.js
+++ b/routes/api.js
@@ -299,15 +299,18 @@ router.get('/list', (req, res, next) => {
         .catch(next);
 });
 
-function parsePositiveLimit(value) {
-    const limit = parseInt(value, 10);
-    if (Number.isNaN(limit) || limit <= 0) return null;
-    return limit;
-}
+router.get('/statistics', (req, res, next) => {
+    const parsedLimit = parseInt(req.query.n, 10);
+    let limit = (parsedLimit > 0) ? parsedLimit : 10;
 
-router.get('/highest_abv', (req, res, next) => {
-    const limit = parsePositiveLimit(req.query.n) || 10;
-    Drinks.aggregate([
+    const allowedStatistics = ['abv', 'emu'];
+    const statistic = allowedStatistics.includes(req.query.stat) ? req.query.stat : 'abv';
+
+    const sortMap = { asc: 1, desc: -1 };
+    const sortOrder = sortMap[(req.query.sort || '').toLowerCase()] || -1;
+
+    if (statistic === 'abv') {
+        Drinks.aggregate([
         {
             $project: {
                 uuid: 1,
@@ -333,47 +336,13 @@ router.get('/highest_abv', (req, res, next) => {
                 }
             }
         },
-        {$sort: {abv: -1, name: 1}},
+        {$sort: {abv: sortOrder, name: 1}},
         {$limit: limit}
-    ]).then((data) => res.json(data)).catch(next);
-});
-
-router.get('/lowest_abv', (req, res, next) => {
-    const limit = parsePositiveLimit(req.query.n) || 10;
-    Drinks.aggregate([
-        {
-            $project: {
-                uuid: 1,
-                name: 1,
-                url_name: 1,
-                tags: 1,
-                glass: 1,
-                abv: {
-                    $let: {
-                        vars: {
-                            drinkVolume: {
-                                $cond: [{$gt: ['$override_volume', 0]}, '$override_volume', '$volume']
-                            }
-                        },
-                        in: {
-                            $cond: [
-                                {$gt: ['$$drinkVolume', 0]},
-                                {$divide: ['$etoh', '$$drinkVolume']},
-                                0
-                            ]
-                        }
-                    }
-                }
-            }
-        },
-        {$sort: {abv: 1, name: 1}},
-        {$limit: limit}
-    ]).then((data) => res.json(data)).catch(next);
-});
-
-router.get('/highest_emu', (req, res, next) => {
-    const limit = parsePositiveLimit(req.query.n) || 10;
-    Drinks.aggregate([
+        ]).then((data) => res.json(data)).catch(next);
+    } 
+    
+    else if (statistic === 'emu') {
+        Drinks.aggregate([
         {
             $project: {
                 uuid: 1,
@@ -390,33 +359,10 @@ router.get('/highest_emu', (req, res, next) => {
                 }
             }
         },
-        {$sort: {emu: -1, name: 1}},
+        {$sort: {emu: sortOrder, name: 1}},
         {$limit: limit}
-    ]).then((data) => res.json(data)).catch(next);
-});
-
-router.get('/lowest_emu', (req, res, next) => {
-    const limit = parsePositiveLimit(req.query.n) || 10;
-    Drinks.aggregate([
-        {
-            $project: {
-                uuid: 1,
-                name: 1,
-                url_name: 1,
-                tags: 1,
-                glass: 1,
-                emu: {
-                    $cond: [
-                        {$gt: ['$etoh', 0]},
-                        {$divide: [{$round: [{$divide: ['$etoh', 5.04]}, 1]}, 10]},
-                        0
-                    ]
-                }
-            }
-        },
-        {$sort: {emu: 1, name: 1}},
-        {$limit: limit}
-    ]).then((data) => res.json(data)).catch(next);
+        ]).then((data) => res.json(data)).catch(next);
+    }
 });
 
 router.get('/search', async (req, res, next) => {

--- a/routes/api.js
+++ b/routes/api.js
@@ -299,6 +299,78 @@ router.get('/list', (req, res, next) => {
         .catch(next);
 });
 
+function parsePositiveLimit(value) {
+    const limit = parseInt(value, 10);
+    if (Number.isNaN(limit) || limit <= 0) return null;
+    return limit;
+}
+
+router.get('/highest_abv', (req, res, next) => {
+    const limit = parsePositiveLimit(req.query.n) || 10;
+    Drinks.aggregate([
+        {
+            $project: {
+                uuid: 1,
+                name: 1,
+                url_name: 1,
+                tags: 1,
+                glass: 1,
+                abv: {
+                    $let: {
+                        vars: {
+                            drinkVolume: {
+                                $cond: [{$gt: ['$override_volume', 0]}, '$override_volume', '$volume']
+                            }
+                        },
+                        in: {
+                            $cond: [
+                                {$gt: ['$$drinkVolume', 0]},
+                                {$divide: ['$etoh', '$$drinkVolume']},
+                                0
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        {$sort: {abv: -1, name: 1}},
+        {$limit: limit}
+    ]).then((data) => res.json(data)).catch(next);
+});
+
+router.get('/lowest_abv', (req, res, next) => {
+    const limit = parsePositiveLimit(req.query.n) || 10;
+    Drinks.aggregate([
+        {
+            $project: {
+                uuid: 1,
+                name: 1,
+                url_name: 1,
+                tags: 1,
+                glass: 1,
+                abv: {
+                    $let: {
+                        vars: {
+                            drinkVolume: {
+                                $cond: [{$gt: ['$override_volume', 0]}, '$override_volume', '$volume']
+                            }
+                        },
+                        in: {
+                            $cond: [
+                                {$gt: ['$$drinkVolume', 0]},
+                                {$divide: ['$etoh', '$$drinkVolume']},
+                                0
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        {$sort: {abv: 1, name: 1}},
+        {$limit: limit}
+    ]).then((data) => res.json(data)).catch(next);
+});
+
 router.get('/search', async (req, res, next) => {
     let pipeline = [];
     let myBarAggregate;


### PR DESCRIPTION
Closes #10 

***Finally*** add sort by ABV statistic (3 years later)

Adds new section on the statistics page showing a list of the highest ABV drinks and a list of the lowest ABV drinks in the database, both styled like the menu card. The number of drinks to show in the list is configurable by setting `process.env.ABV_STATS_LIST_LENGTH`, but defaults to 10

The lists are populated using two new API endpoints, `/api/highest_abv?n=${ABV_STATS_LIST_LENGTH}` and `/api/lowest_abv?n=${ABV_STATS_LIST_LENGTH}`, so all the database ABV calculation and sorting is handled server side. Both endpoints use overridden drink volumes, if entered. `/highest_abv` returns a list sorted first by *descending* ABV, then by name (in the case of ABV ties). `/lowest_abv` returns a list sorted first by *ascending* ABV, then by name (in the case of ABV ties)