### PR TITLE
Reserve space for eraser in search container

### DIFF
--- a/client/src/format/DrinkList.css
+++ b/client/src/format/DrinkList.css
@@ -31,6 +31,7 @@
     display: flex;
     justify-content: center;
     padding-bottom: 10px;
+    padding-left: 10px
 }
 
 .search-bar {

--- a/client/src/format/FilterPanel.css
+++ b/client/src/format/FilterPanel.css
@@ -29,6 +29,7 @@
 .filter-eraser {
     float: right;
     margin: 5px 0 0 10px;
+    width: 26px;
 }
 
 .filter-panel-container {
@@ -55,9 +56,15 @@
 .filter-toggle {
     float: right;
     margin: 5px 0 0 10px;
+    width: 26px;
 }
 
 @media screen and (max-width: 600px) {
+    .filter-eraser {
+        margin: 6px 5px 0 1px;
+        width: 0px;
+    }
+    
     .filter-panel-container {
         margin-left: 0px;
         width: 100%;
@@ -72,6 +79,10 @@
     
     .filter-panel-title {
         margin: 10px 0 0 0;
+    }
+
+    .filter-toggle {
+        margin: 6px 0 0 10px;
     }
     
     .unselected-tag-filter {

--- a/client/src/pages/DrinkList.js
+++ b/client/src/pages/DrinkList.js
@@ -120,10 +120,12 @@ const DrinkList = ({setShowLoader, user, setUser, searchText, setSearchText, sea
                         {!filterPanelShown && <FaChevronCircleDown style={{cursor:"pointer", marginRight: '10px'}} onClick={toggleFilterPanel}/>}
                         {filterPanelShown && <FaChevronCircleUp style={{cursor:"pointer", marginRight: '10px'}} onClick={toggleFilterPanel}/>}
                     </div>
-                    {showEraser() && <div className='filter-eraser'><FaEraser style={{cursor:"pointer"}} onClick={clearSearchParams}/></div>}
+                    <div className='filter-eraser'>
+                        {showEraser() && <FaEraser style={{cursor:"pointer"}} onClick={clearSearchParams}/>}
+                    </div>
                 </div>
             </header>
-            <div className={'filter-panel'}>
+            <div className="filter-panel">
                 <FilterPanel expandFilterPanel={expandFilterPanel} toggleFilterPanel={toggleFilterPanel} user={user} searchIngredient={searchIngredient} setSearchIngredient={setSearchIngredient} searchTags={searchTags} setSearchTags={setSearchTags} myBarSearch={myBarSearch} setMyBarSearch={setMyBarSearch}/>
             </div>
             {listLoaded && <>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mixd",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Closes #200.

Resolves pop in issue where selecting a tag in the filter pane would suddenly shift the entire search container over to make room for the eraser icon